### PR TITLE
adwaita-dark: make border colors consistent

### DIFF
--- a/button-themes/svg/Adwaita-dark/openbox-3/close_hover-inactive.svg
+++ b/button-themes/svg/Adwaita-dark/openbox-3/close_hover-inactive.svg
@@ -52,7 +52,7 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"><circle
-       style="fill:#242424;fill-opacity:1;stroke:none;stroke-width:0.529165;stroke-linecap:square;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#303030;fill-opacity:1;stroke:none;stroke-width:0.529165;stroke-linecap:square;stroke-dasharray:none;stroke-opacity:1"
        id="circle2"
        cx="3.4395833"
        cy="3.4395833"

--- a/button-themes/svg/Adwaita-dark/openbox-3/iconify-inactive.svg
+++ b/button-themes/svg/Adwaita-dark/openbox-3/iconify-inactive.svg
@@ -52,7 +52,7 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"><circle
-       style="fill:#303030;fill-opacity:1;stroke:none;stroke-width:0.529165;stroke-linecap:square;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:#242424;fill-opacity:1;stroke:none;stroke-width:0.529165;stroke-linecap:square;stroke-dasharray:none;stroke-opacity:1"
        id="circle2"
        cx="3.4395833"
        cy="3.4395833"


### PR DESCRIPTION
Fixes a small inconsistency in the outer circle for the inactive icons.

cc: @davidphilipbarr 